### PR TITLE
Order GET parameters alphabetically

### DIFF
--- a/tests/test_url_normalize.py
+++ b/tests/test_url_normalize.py
@@ -114,6 +114,8 @@ EXPECTED_CHANGES = [
     (False, "http://127.0.0.1:80/"),
     (True, "http://www.w3.org/2000/01/rdf-schema#"),
     (False, "http://example.com:081/"),
+    (True, "http://example.com/?a&b"),
+    (False, "http://example.com/?b&a"),
 ]
 
 

--- a/url_normalize/url_normalize.py
+++ b/url_normalize/url_normalize.py
@@ -114,9 +114,9 @@ def url_normalize(url, charset='utf-8'):
 
     # note care must be taken to only encode & and = characters as values
     query = "&".join(
-        ["=".join(
+        sorted(["=".join(
             [quote(_clean(t), "~:/?#[]@!$'()*+,;=")
-             for t in q.split("=", 1)]) for q in query.split("&")])
+             for t in q.split("=", 1)]) for q in query.split("&")]))
 
     # Prevent dot-segments appearing in non-relative URI paths.
     if scheme in ["", "http", "https", "ftp", "file"]:


### PR DESCRIPTION
Hi, in my tests I would like to compare urls even if the ordering of the GET parameters is off. As [wikipedia](https://en.wikipedia.org/wiki/URL_normalization) say, this may be too aggressive.

I can add this as an option also.