### PR TITLE
Don't append slash if the url has none

### DIFF
--- a/url_normalize/url_normalize.py
+++ b/url_normalize/url_normalize.py
@@ -161,4 +161,14 @@ def url_normalize(url, charset='utf-8'):
     if url.endswith("#") and query == "" and fragment == "":
         path += "#"
 
-    return urlunsplit((scheme, auth, path, query, fragment))
+    # Check if url was clear of ending slash
+    endingSlashNotPresent = not url.endswith('/')
+
+    # Unsplit
+    url = urlunsplit((scheme, auth, path, query, fragment))
+
+    # Remove ending slash if url was clear of it before urlunsplit
+    if url.endswith('/') and endingSlashNotPresent:
+        url = url[:-1]
+
+    return url


### PR DESCRIPTION
When the url doesn't have any sub path after domain then urlunsplit appends slash to it. This PR intends to fix that.

Old behavior:
"https://example.com"	---normalization--->  "https://example.com/"
"https://example.com/"	---normalization--->  "https://example.com/"

New fixed behavior:
"https://example.com"	---normalization--->  "https://example.com"
"https://example.com/"	---normalization--->  "https://example.com/"