### PR TITLE
Remove shebang & feedburner removals

### DIFF
--- a/url_normalize/url_normalize.py
+++ b/url_normalize/url_normalize.py
@@ -85,12 +85,6 @@ def url_normalize(url, charset='utf-8'):
     if url[0] not in ['/', '-'] and ':' not in url[:7]:
         url = 'http://' + url
 
-    # shebang urls support
-    url = url.replace('#!', '?_escaped_fragment_=')
-
-    # remove feedburner's crap
-    url = re.sub(r'\?utm_source=feedburner.+$', '', url)
-
     # splitting url to useful parts
     scheme, auth, path, query, fragment = urlsplit(url.strip())
     (userinfo, host, port) = re.search('([^@]*@)?([^:]*):?(.*)', auth).groups()


### PR DESCRIPTION
This library should only normalize URLs not change their contents. Feedburner UTM tag is a part of valid URL, it shouldn't be stripped. The same thing with the shebangs.