### PR TITLE
Use HTTPS as a default scheme

### DIFF
--- a/url_normalize/url_normalize.py
+++ b/url_normalize/url_normalize.py
@@ -83,7 +83,7 @@ def url_normalize(url, charset='utf-8'):
     """
     # if there is no scheme use http as default scheme
     if url[0] not in ['/', '-'] and ':' not in url[:7]:
-        url = 'http://' + url
+        url = 'https://' + url
 
     # shebang urls support
     url = url.replace('#!', '?_escaped_fragment_=')


### PR DESCRIPTION
HTTP was a good default some time ago. But now most of the websites are moving to HTTPS and also modern browsers like Chrome, Firefox, Edge, Opera, etc. are defaulting urls without scheme to HTTPS (e.g. "//example.com" will get defaulted to "https://example.com"). So I think it makes more sense now to use HTTPS instead HTTP as a default.