### PR TITLE
Add type hints

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,10 +16,12 @@ version = "1.4.3"
 [tool.poetry.dependencies]
 python = "~2.7 || ^3.6"
 six = "*"
+typing = [{version="~3.6", python="~2.7"}]
 
 [tool.poetry.dev-dependencies]
 bandit = [{version="*", python="^3.6"}]
 flake8 = [{version="*", python="^3.6"}]
+mypy = [{version="~0.790", python="^3.6"}]
 pluggy = [{version="0.13.1", python="~2.7"}]
 pydocstyle = [{version="*", python="^3.6"}]
 pylint = [{version="*", python="^3.6"}]

--- a/tests/test_deconstruct_url.py
+++ b/tests/test_deconstruct_url.py
@@ -23,7 +23,7 @@ EXPECTED_DATA = {
 }
 
 
-def test_deconstruct_url_result_is_expected():
+def test_deconstruct_url_result_is_expected():  # type: () -> None
     """Assert we got expected results from the deconstruct_url function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_generic_url_cleanup.py
+++ b/tests/test_generic_url_cleanup.py
@@ -11,7 +11,7 @@ EXPECTED_DATA = {
 }
 
 
-def test_generic_url_cleanup_result_is_expected():
+def test_generic_url_cleanup_result_is_expected():  # type: () -> None
     """Assert we got expected results from the generic_url_cleanup function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_normalize_fragment.py
+++ b/tests/test_normalize_fragment.py
@@ -11,7 +11,7 @@ EXPECTED_DATA = {
 }
 
 
-def test_normalize_fragment_result_is_expected():
+def test_normalize_fragment_result_is_expected():  # type: () -> None
     """Assert we got expected results from the normalize_fragment function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_normalize_host.py
+++ b/tests/test_normalize_host.py
@@ -10,7 +10,7 @@ EXPECTED_DATA = {
 }
 
 
-def test_normalize_host_result_is_expected():
+def test_normalize_host_result_is_expected():  # type: () -> None
     """Assert we got expected results from the normalize_host function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_normalize_path.py
+++ b/tests/test_normalize_path.py
@@ -31,7 +31,7 @@ EXPECTED_DATA = {
 }
 
 
-def test_normalize_host_result_is_expected():
+def test_normalize_host_result_is_expected():  # type: () -> None
     """Assert we got expected results from the normalize_path function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_normalize_port.py
+++ b/tests/test_normalize_port.py
@@ -4,7 +4,7 @@ from url_normalize.url_normalize import normalize_port
 EXPECTED_DATA = {"8080": "8080", "": "", "80": "", "string": "string"}
 
 
-def test_normalize_port_result_is_expected():
+def test_normalize_port_result_is_expected():  # type: () -> None
     """Assert we got expected results from the normalize_port function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_normalize_query.py
+++ b/tests/test_normalize_query.py
@@ -12,7 +12,7 @@ EXPECTED_DATA = {
 }
 
 
-def test_normalize_query_result_is_expected():
+def test_normalize_query_result_is_expected():  # type: () -> None
     """Assert we got expected results from the normalize_query function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_normalize_scheme.py
+++ b/tests/test_normalize_scheme.py
@@ -4,7 +4,7 @@ from url_normalize.url_normalize import normalize_scheme
 EXPECTED_DATA = {"http": "http", "HTTP": "http"}
 
 
-def test_normalize_scheme_result_is_expected():
+def test_normalize_scheme_result_is_expected():  # type: () -> None
     """Assert we got expected results from the normalize_scheme function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_normalize_userinfo.py
+++ b/tests/test_normalize_userinfo.py
@@ -10,7 +10,7 @@ EXPECTED_DATA = {
 }
 
 
-def test_normalize_userinfo_result_is_expected():
+def test_normalize_userinfo_result_is_expected():  # type: () -> None
     """Assert we got expected results from the normalize_userinfo function."""
     for url, expected in EXPECTED_DATA.items():
 

--- a/tests/test_provide_url_scheme.py
+++ b/tests/test_provide_url_scheme.py
@@ -11,7 +11,7 @@ EXPECTED_DATA = {
 }
 
 
-def test_provide_url_scheme_result_is_expected():
+def test_provide_url_scheme_result_is_expected():  # type: () -> None
     """Assert we got expected results from the provide_url_scheme function."""
     for url, expected in EXPECTED_DATA.items():
 
@@ -20,7 +20,7 @@ def test_provide_url_scheme_result_is_expected():
         assert result == expected, url
 
 
-def test_provide_url_scheme_accept_default_scheme_param():
+def test_provide_url_scheme_accept_default_scheme_param():  # type: () -> None
     """Assert we could provide default_scheme param other than https."""
     url = "//site/path"
     expected = "http://site/path"

--- a/tests/test_reconstruct_url.py
+++ b/tests/test_reconstruct_url.py
@@ -29,7 +29,7 @@ EXPECTED_DATA = (
 )
 
 
-def test_deconstruct_url_result_is_expected():
+def test_deconstruct_url_result_is_expected():  # type: () -> None
     """Assert we got expected results from the deconstruct_url function."""
     for url, expected in EXPECTED_DATA:
 

--- a/tests/test_url_normalize.py
+++ b/tests/test_url_normalize.py
@@ -80,7 +80,7 @@ NO_CHANGES_EXPECTED = (
 )
 
 
-def test_url_normalize_changes():
+def test_url_normalize_changes():  # type: () -> None
     """Assert url_normalize do not change URI if not required.
 
     http://www.intertwingly.net/wiki/pie/PaceCanonicalIds
@@ -89,13 +89,13 @@ def test_url_normalize_changes():
         assert url_normalize(value) == value
 
 
-def test_url_normalize_results():
+def test_url_normalize_results():  # type: () -> None
     """Assert url_normalize return expected results."""
     for value, expected in EXPECTED_RESULTS.items():
         assert expected == url_normalize(value), value
 
 
-def test_url_normalize_with_http_scheme():
+def test_url_normalize_with_http_scheme():  # type: () -> None
     """Assert we could use http scheme as default."""
     url = "//www.foo.com/"
     expected = "http://www.foo.com/"
@@ -105,7 +105,7 @@ def test_url_normalize_with_http_scheme():
     assert actual == expected
 
 
-def test_url_normalize_with_no_params_sorting():
+def test_url_normalize_with_no_params_sorting():  # type: () -> None
     """Assert we could use http scheme as default."""
     url = "http://www.foo.com/?b=1&a=2"
     expected = "http://www.foo.com/?b=1&a=2"

--- a/tox.ini
+++ b/tox.ini
@@ -23,3 +23,7 @@ python_files = tests.py test_*.py *_tests.py
 max-line-length = 80
 select = C,E,F,W,B,B950
 ignore = E501
+
+[mypy]
+python_version = 2.7
+strict = True

--- a/url_normalize/tools.py
+++ b/url_normalize/tools.py
@@ -2,6 +2,7 @@
 import re
 import unicodedata
 from collections import namedtuple
+from typing import Match, Union, cast
 
 import six
 from six.moves.urllib.parse import quote as quote_orig
@@ -13,8 +14,8 @@ URL = namedtuple(
 )
 
 
-def deconstruct_url(url):
-    """Tranform the url into URL structure.
+def deconstruct_url(url):  # type: (str) -> URL
+    """Transform the url into URL structure.
 
     Params:
         url : string : the URL
@@ -24,7 +25,8 @@ def deconstruct_url(url):
 
     """
     scheme, auth, path, query, fragment = urlsplit(url.strip())
-    (userinfo, host, port) = re.search("([^@]*@)?([^:]*):?(.*)", auth).groups()
+    # cast: the regex matches anything
+    (userinfo, host, port) = cast(Match[str], re.search("([^@]*@)?([^:]*):?(.*)", auth)).groups()
     return URL(
         fragment=fragment,
         host=host,
@@ -36,7 +38,7 @@ def deconstruct_url(url):
     )
 
 
-def reconstruct_url(url):
+def reconstruct_url(url):  # type: (URL) -> str
     """Reconstruct string url from URL.
 
     Params:
@@ -49,10 +51,11 @@ def reconstruct_url(url):
     auth = (url.userinfo or "") + url.host
     if url.port:
         auth += ":" + url.port
-    return urlunsplit((url.scheme, auth, url.path, url.query, url.fragment))
+    # cast: needed when checking as python 2.7, redundant with 3.6+
+    return cast(str, urlunsplit((url.scheme, auth, url.path, url.query, url.fragment)))
 
 
-def force_unicode(string, charset="utf-8"):
+def force_unicode(string, charset="utf-8"):  # type: (Union[bytes, str], str) -> str
     """Convert string to unicode if it is not yet unicode.
 
     Params:
@@ -68,7 +71,7 @@ def force_unicode(string, charset="utf-8"):
     return string.decode(charset, "replace")  # Py2 only
 
 
-def unquote(string, charset="utf-8"):
+def unquote(string, charset="utf-8"):  # type: (str, str) -> bytes
     """Unquote and normalize unicode string.
 
     Params:
@@ -81,11 +84,11 @@ def unquote(string, charset="utf-8"):
     """
     string = unquote_orig(string)
     string = force_unicode(string, charset)
-    string = unicodedata.normalize("NFC", string).encode(charset)
-    return string
+    bstring = unicodedata.normalize("NFC", string).encode(charset)
+    return bstring
 
 
-def quote(string, safe="/"):
+def quote(string, safe="/"):  # type: (Union[bytes, str], Union[bytes, str]) -> str
     """Quote string.
 
     Params:

--- a/url_normalize/url_normalize.py
+++ b/url_normalize/url_normalize.py
@@ -1,6 +1,9 @@
 # -*- coding: utf-8 -*-
 """URL normalize main module."""
 import re
+from typing import List
+
+import six
 
 from .tools import deconstruct_url, force_unicode, quote, reconstruct_url, unquote
 
@@ -21,7 +24,7 @@ DEFAULT_CHARSET = "utf-8"
 DEFAULT_SCHEME = "https"
 
 
-def provide_url_scheme(url, default_scheme=DEFAULT_SCHEME):
+def provide_url_scheme(url, default_scheme=DEFAULT_SCHEME):  # type: (str, str) -> str
     """Make sure we have valid url scheme.
 
     Params:
@@ -42,7 +45,7 @@ def provide_url_scheme(url, default_scheme=DEFAULT_SCHEME):
     return default_scheme + "://" + url
 
 
-def generic_url_cleanup(url):
+def generic_url_cleanup(url):  # type: (str) -> str
     """Cleanup the URL from unnecessary data and convert to final form.
 
     Converts shebang urls to final form, removed unnecessary data from the url.
@@ -60,7 +63,7 @@ def generic_url_cleanup(url):
     return url
 
 
-def normalize_scheme(scheme):
+def normalize_scheme(scheme):  # type: (str) -> str
     """Normalize scheme part of the url.
 
     Params:
@@ -73,7 +76,7 @@ def normalize_scheme(scheme):
     return scheme.lower()
 
 
-def normalize_userinfo(userinfo):
+def normalize_userinfo(userinfo):  # type: (str) -> str
     """Normalize userinfo part of the url.
 
     Params:
@@ -88,7 +91,7 @@ def normalize_userinfo(userinfo):
     return userinfo
 
 
-def normalize_host(host, charset=DEFAULT_CHARSET):
+def normalize_host(host, charset=DEFAULT_CHARSET):  # type: (str, str) -> six.text_type
     """Normalize host part of the url.
 
     Lowercase and strip of final dot.
@@ -104,11 +107,11 @@ def normalize_host(host, charset=DEFAULT_CHARSET):
     host = force_unicode(host, charset)
     host = host.lower()
     host = host.strip(".")
-    host = host.encode("idna").decode(charset)
-    return host
+    uhost = host.encode("idna").decode(charset)
+    return uhost
 
 
-def normalize_port(port, scheme):
+def normalize_port(port, scheme):  # type: (str, str) -> str
     """Normalize port part of the url.
 
     Remove mention of default port number
@@ -129,7 +132,7 @@ def normalize_port(port, scheme):
     return port
 
 
-def normalize_path(path, scheme):
+def normalize_path(path, scheme):  # type: (str, str) -> str
     """Normalize path part of the url.
 
     Remove mention of default path number
@@ -148,7 +151,8 @@ def normalize_path(path, scheme):
     path = quote(unquote(path), "~:/?#[]@!$&'()*+,;=")
     # Prevent dot-segments appearing in non-relative URI paths.
     if scheme in ["", "http", "https", "ftp", "file"]:
-        output, part = [], None
+        output = []  # type: List[str]
+        part = None
         for part in path.split("/"):
             if part == "":
                 if not output:
@@ -170,7 +174,7 @@ def normalize_path(path, scheme):
     return path
 
 
-def normalize_fragment(fragment):
+def normalize_fragment(fragment):  # type: (str) -> str
     """Normalize fragment part of the url.
 
     Params:
@@ -183,7 +187,7 @@ def normalize_fragment(fragment):
     return quote(unquote(fragment), "~")
 
 
-def normalize_query(query, sort_query_params=True):
+def normalize_query(query, sort_query_params=True):  # type: (str, bool) -> str
     """Normalize query part of the url.
 
     Params:
@@ -205,7 +209,7 @@ def normalize_query(query, sort_query_params=True):
 
 def url_normalize(
     url, charset=DEFAULT_CHARSET, default_scheme=DEFAULT_SCHEME, sort_query_params=True
-):
+):  # type: (str, str, str, bool) -> str
     """URI normalization routine.
 
     Sometimes you get an URL by a user that just isn't a real


### PR DESCRIPTION
This adds type hints to the entire tree. I'm not familiar with poetry, so not quite sure I got the dependencies right: with 3.6+, typing is in stdlib so no need to add a separate dependency; and I added mypy dev dep for 3.6+ only to follow what's being done with bandit, flake8, pylint and tox.

I did not feel like adding a separate config file for mypy config and it doesn't support pyproject.toml yet, so to check, invoke
```
mypy --config-file tox.ini url_normalize tests
```
I didn't find a place in the tree where the tool invocations would be specified, so there was no place I could add the above to.

Includes unrelated `deconstruct_url` docstring typo fix which I'm too lazy to submit separately.