### PR TITLE
Fix relative path with a file in between

### DIFF
--- a/tests/test_url_normalize.py
+++ b/tests/test_url_normalize.py
@@ -43,6 +43,7 @@ EXPECTED_RESULTS = {
     "http://www.foo.com:80/foo": "http://www.foo.com/foo",
     "http://www.foo.com.:81/foo": "http://www.foo.com:81/foo",
     "http://www.foo.com./foo/bar.html": "http://www.foo.com/foo/bar.html",
+    "http://www.foo.com/foo/bar.html/../bar.html": "http://www.foo.com/bar.html",
     "http://www.foo.com/%7Ebar": "http://www.foo.com/~bar",
     "http://www.foo.com/%7ebar": "http://www.foo.com/~bar",
     "пример.испытание/Служебная:Search/Test": "https://xn--e1afmkfd.xn--80akhbyknj4f/%D0%A1%D0%BB%D1%83%D0%B6%D0%B5%D0%B1%D0%BD%D0%B0%D1%8F:Search/Test",

--- a/url_normalize/url_normalize.py
+++ b/url_normalize/url_normalize.py
@@ -149,7 +149,9 @@ def normalize_path(path, scheme):
     # Prevent dot-segments appearing in non-relative URI paths.
     if scheme in ["", "http", "https", "ftp", "file"]:
         output, part = [], None
-        for part in path.split("/"):
+        parts = path.split("/")
+        last_idx = len(parts) - 1
+        for idx, part in enumerate(parts):
             if part == "":
                 if not output:
                     output.append(part)
@@ -158,6 +160,8 @@ def normalize_path(path, scheme):
             elif part == "..":
                 if len(output) > 1:
                     output.pop()
+            elif re.search(r'\.', part) and idx != last_idx:
+                pass
             else:
                 output.append(part)
         if part in ["", ".", ".."]:


### PR DESCRIPTION
The correct answer for `http://www.foo.com/foo/bar.html/../bar.html` is `http://www.foo.com/bar.html`, but it returns `http://www.foo.com/foo/bar.html` instead, regarding `bar.html` as a folder.