### PR TITLE
fix: Stop using the `transitional` argument of `idna.decode()` now that it no longer has any effect

### DIFF
--- a/tests/test_normalize_host.py
+++ b/tests/test_normalize_host.py
@@ -17,7 +17,7 @@ from url_normalize.url_normalize import normalize_host
         # Mixed case with Cyrillic
         ("ExAmPle.РФ", "example.xn--p1ai"),
         # IDNA2008 with UTS46
-        ("faß.de", "fass.de"),  # Normalize using transitional rules
+        ("faß.de", "xn--fa-hia.de"),
         # Edge cases
         ("ドメイン.テスト", "xn--eckwd4c7c.xn--zckzah"),  # Japanese
         ("domain.café", "domain.xn--caf-dma"),  # Latin with diacritic

--- a/url_normalize/normalize_host.py
+++ b/url_normalize/normalize_host.py
@@ -13,7 +13,7 @@ def normalize_host(host: str, charset: str = DEFAULT_CHARSET) -> str:
     """Normalize host part of the url.
 
     Lowercase and strip of final dot.
-    Also, handle IDN domains using IDNA2008 with UTS46 transitional processing.
+    Also, handle IDN domains using IDNA2008 with UTS46 processing.
 
     Params:
         host : string : url host, e.g., 'site.com'
@@ -32,7 +32,7 @@ def normalize_host(host: str, charset: str = DEFAULT_CHARSET) -> str:
     try:
         # Process each label separately to handle mixed unicode/ascii domains
         parts = [
-            idna.encode(p, uts46=True, transitional=True).decode(charset)
+            idna.encode(p, uts46=True).decode(charset)
             for p in parts
             if p
         ]


### PR DESCRIPTION
idna made `transitional` a no-op in 3.11 and started raising a deprecation warning in 3.12. This PR removes usage oof the argument and updates the one failing test.

## Links

- https://github.com/kjd/idna/releases/tag/v3.11
- https://github.com/kjd/idna/releases/tag/v3.12